### PR TITLE
Add caching of LFS files on GitHub Actions

### DIFF
--- a/.github/actions/cache-and-pull-lfs/action.yml
+++ b/.github/actions/cache-and-pull-lfs/action.yml
@@ -1,0 +1,26 @@
+name: Cache and pull Git LFS files
+description: Cache and pull Git LFS files
+inputs:
+  path:
+    required: true
+    description: Path of LFS files to cache and pull
+runs:
+  using: composite
+  steps:
+    - name: Save LFS file listing
+      shell: bash
+      run: |
+        git lfs ls-files --include='${{ inputs.path }}' > .lfs-listing
+
+    - name: Restore LFS cache
+      uses: actions/cache@v4
+      with:
+        path: .git/lfs/objects
+        key: lfs-${{ inputs.path }}-${{ hashFiles('.lfs-listing') }}
+        restore-keys: |
+          lfs-${{ inputs.path }}-
+
+    - name: Pull LFS files
+      shell: bash
+      run: |
+        git lfs pull --include='${{ inputs.path }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,13 @@ name: Lint, test and deploy
 
 on:
   pull_request:
-  workflow_call:
-  workflow_dispatch:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 2 * * 0"
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -51,7 +53,9 @@ jobs:
         run: npm ci
 
       - name: Pull LFS source files
-        run: git lfs pull --include=src
+        uses: ./.github/actions/cache-and-pull-lfs
+        with:
+          path: src
 
       - name: Restore Astro cache
         uses: actions/cache@v4
@@ -120,10 +124,14 @@ jobs:
       - name: Unpack site
         run: tar -xzf /tmp/site.tar.gz
 
-      - name: Pull LFS test snapshots
+      - name: Mark Git directory as safe
         run: |
           git config --global --add safe.directory "$(pwd)"
-          git lfs pull --include=test/e2e
+
+      - name: Pull LFS test snapshots
+        uses: ./.github/actions/cache-and-pull-lfs
+        with:
+          path: test/e2e
 
       - name: Run e2e tests
         run: npm exec --no -- playwright test


### PR DESCRIPTION
This adds caching of LFS files on GitHub Actions, to reduce usage of GitHub's LFS data transfer quota.

As GitHub Actions caches expire after 7 days, a weekly scheduled job has been added to try to stop the cache being purged.